### PR TITLE
Add decode custom filter in order to decode bytes from attachments

### DIFF
--- a/report.py
+++ b/report.py
@@ -40,6 +40,7 @@ class Jinja2Report(metaclass=PoolMeta):
         translations = cls.get_translations()
         env.install_gettext_translations(translations)
         env.filters['b64encode'] = b64encode
+        env.filters['decode'] = bytes.decode
         return env
 
     @classmethod

--- a/tests/test_jinja_report.py
+++ b/tests/test_jinja_report.py
@@ -68,7 +68,8 @@ class JinjaReportTestCase(ModuleTestCase):
             extension='html',
             template_extension='html',
             report_content_custom=(
-                b"{{ attachments(record, 'example.png') | b64encode }}"
+                b"{{ attachments(record, 'example.png') "
+                b"| b64encode | decode }}"
             ),
         )
         Report = Pool().get(report.report_name, type='report')
@@ -80,9 +81,9 @@ class JinjaReportTestCase(ModuleTestCase):
         self.assertEqual(
             report_data,
             (
-                "b'iVBORw0KGgoAAAANSUhEUgAAAAIAAAACCAIAAAD91JpzAAAAAXNSR0IArs"
+                "iVBORw0KGgoAAAANSUhEUgAAAAIAAAACCAIAAAD91JpzAAAAAXNSR0IArs"
                 "4c6QAAAARnQU1BAACxjwv8YQUAAAAJcEhZcwAADsMAAA7DAcdvqGQAAAAVSU"
-                "RBVBhXY3hnZPVWTo0BiN/buQIAJsQFL0PuuMYAAAAASUVORK5CYII='"
+                "RBVBhXY3hnZPVWTo0BiN/buQIAJsQFL0PuuMYAAAAASUVORK5CYII="
             )
         )
 


### PR DESCRIPTION
When filling an image in template based on base64, custom filter b64encode returns a byteobject, but a string
is needed.